### PR TITLE
Parse SAS "title" for first page and "Title" for more info page to correctly display SAS apps.

### DIFF
--- a/bin/PLG/gme_0_xSasApps.xml
+++ b/bin/PLG/gme_0_xSasApps.xml
@@ -12,8 +12,8 @@
 				let ELFPath = "";
 
 				// Get Title
-				if ('Title' in data) { AppName = data['Title'];	}
-				else if ('title' in data) {	AppName = data['title']; }
+				if ('title' in data) { AppName = data['title'];	}
+				else if ('Title' in data) {	AppName = data['Title']; }
 
 				// Get ELF Path
 				if ('boot' in data) { ELFPath = `${path}${data['boot']}`; }


### PR DESCRIPTION
title and Title were swapped. This makes it consistent with how title.cfg is supposed to be used between apps such as OPL